### PR TITLE
fix assignement error

### DIFF
--- a/Foundation/library/source/TTFoundation.cpp
+++ b/Foundation/library/source/TTFoundation.cpp
@@ -306,7 +306,7 @@ TTErr TTFoundationLoadExternalClassesFromFolder(const TTString& fullpath)
 	dirent* dp;
 	while ((dp = readdir(dirp))) {
 		TTString	fileName(dp->d_name);
-		char*		cFileSuffix = strrchr(fileName.c_str(), '.');
+		const char*		cFileSuffix = strrchr(fileName.c_str(), '.');
 		if (!cFileSuffix)
 			continue;
 		TTString	fileSuffix(cFileSuffix);


### PR DESCRIPTION
on Ubuntu 14.04 with clang++ 3.4-1ubuntu3 assigning a `const char*` to a `char *` throw an error and build fails
