### PR TITLE
Feature/extension check

### DIFF
--- a/Foundation/library/source/TTExtensionLoader.cpp
+++ b/Foundation/library/source/TTExtensionLoader.cpp
@@ -1,6 +1,7 @@
 #include "TTExtensionLoader.h"
 #include "TTFoundation.h"
 #include "TTEnvironment.h"
+#include "JamomaCoreVersion.h"
 #include <vector>
 #include <string>
 
@@ -78,6 +79,7 @@ string TTFilenameToExtensionName(string name)
 	return name;
 }
 
+
 template<typename OS, typename Loader, typename GetProc>
 // A generic way to load classes.
 // Loader  : a callable object that takes a filename of a shared object,
@@ -98,6 +100,13 @@ bool TTLoadExtension(const string& filename,
 	if (!handle)
 	{
 		TTLogMessage("Error when trying to get an handle on %s.\n", filename.c_str());
+		return false;
+	}
+
+	// Check if the extension is compatible.
+	auto compatfun = reinterpret_cast<bool (*)(const char*)>(getproc_fun(handle, "TTExtensionCompatibilityCheck"));
+	if(!compatfun || (compatfun && !compatfun(JAMOMACORE_REV)))
+	{
 		return false;
 	}
 

--- a/Shared/CMake/JamomaUtilFunctions.cmake
+++ b/Shared/CMake/JamomaUtilFunctions.cmake
@@ -121,6 +121,14 @@ function(add_jamoma_extension)
 				SHARED
 				${PROJECT_SRCS} ${PROJECT_HDRS})
 
+    # TODO this is an obstacle to static extensions.
+    get_property(EXTENSION_SOURCES
+                 TARGET ${PROJECT_NAME}
+                 PROPERTY SOURCES)
+
+    set_property(TARGET ${PROJECT_NAME}
+                 PROPERTY SOURCES "${EXTENSION_SOURCES};${CMAKE_MODULE_PATH}/../../JamomaGitInfo.cpp")
+
 	target_link_libraries(${PROJECT_NAME} PUBLIC ${JAMOMA_CURRENT_LIBRARY_NAME})
 
 	# Rpath

--- a/Shared/JamomaGitInfo.cpp
+++ b/Shared/JamomaGitInfo.cpp
@@ -1,0 +1,11 @@
+#include "JamomaCoreVersion.h"
+#include <string>
+/**
+* Will check that the current extension can be loaded
+* by the version given in argument in git_tag.
+*/
+bool TTExtensionCompatibilityCheck(const char* git_tag)
+{
+    static const std::string rev(JAMOMACORE_REV);
+    return rev != git_tag;
+}

--- a/Shared/JamomaGitInfo.cpp
+++ b/Shared/JamomaGitInfo.cpp
@@ -3,9 +3,12 @@
 /**
 * Will check that the current extension can be loaded
 * by the version given in argument in git_tag.
+* 
+* Returns true if the extension is compatible with the loading 
+* dylib.
 */
 bool TTExtensionCompatibilityCheck(const char* git_tag)
 {
     static const std::string rev(JAMOMACORE_REV);
-    return rev != git_tag;
+    return rev == git_tag;
 }


### PR DESCRIPTION
Hello,

Here is a small pull request that intends to fix the problems that Trond is encountering wrt old Jamoma dylibs present in the default search paths, which is a requirement for people using jamoma 0.5. 

It just adds a check against to the git commit hash when loading the dylibs and will skip dylibs that don't have the data embedded.

@lossius could you try it ?