### PR TITLE
Cmake: when building for Max on the Mac, don't include the version nu…

### DIFF
--- a/Shared/CMake/JamomaUtilFunctions.cmake
+++ b/Shared/CMake/JamomaUtilFunctions.cmake
@@ -201,19 +201,21 @@ function(add_jamoma_extension)
 	
 	if(APPLE)
 		if(BUILD_JAMOMAMAX)
-			ADD_CUSTOM_COMMAND(
-			  TARGET ${PROJECT_NAME}
-			  POST_BUILD
-			  COMMAND ${CMAKE_COMMAND} -E make_directory
-			   ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
-			)
-			ADD_CUSTOM_COMMAND(
-			  TARGET ${PROJECT_NAME} #Jamoma::Foundation # for instance
-			  POST_BUILD
-			  COMMAND ${CMAKE_COMMAND} -E copy
-			      ${CMAKE_BINARY_DIR}/JamomaCore/${JAMOMA_CURRENT_LIBRARY_NAME}/extensions/${PROJECT_NAME}/${CMAKE_BUILD_TYPE}/${PROJECT_NAME}.ttdylib #* # we have to be careful with .so / .dll
-			      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
-			)
+			if(!$ENV{TRAVIS})			
+				ADD_CUSTOM_COMMAND(
+				  TARGET ${PROJECT_NAME}
+				  POST_BUILD
+				  COMMAND ${CMAKE_COMMAND} -E make_directory
+				   ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+				)
+				ADD_CUSTOM_COMMAND(
+				  TARGET ${PROJECT_NAME} #Jamoma::Foundation # for instance
+				  POST_BUILD
+				  COMMAND ${CMAKE_COMMAND} -E copy
+				      ${CMAKE_BINARY_DIR}/JamomaCore/${JAMOMA_CURRENT_LIBRARY_NAME}/extensions/${PROJECT_NAME}/${CMAKE_BUILD_TYPE}/${PROJECT_NAME}.ttdylib #* # we have to be careful with .so / .dll
+				      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
+				)
+			endif() # !$ENV{TRAVIS}
 		endif() # BUILD_JAMOMAMAX
 	endif() # APPLE
 	

--- a/Shared/CMake/JamomaUtilFunctions.cmake
+++ b/Shared/CMake/JamomaUtilFunctions.cmake
@@ -10,6 +10,8 @@ function(setupJamomaLibraryProperties LIBNAME)
     	if(APPLE)
         	set_property(TARGET ${PROJECT_NAME}
                      	PROPERTY INSTALL_RPATH "@loader_path/../../../../support;@loader_path")
+			set_property(TARGET ${PROJECT_NAME}
+						 PROPERTY BUILD_WITH_INSTALL_RPATH TRUE)						
     	else()
         	set_property(TARGET ${PROJECT_NAME}
                      	PROPERTY INSTALL_RPATH "\$ORIGIN/../support;\$ORIGIN")
@@ -27,12 +29,14 @@ function(setupJamomaLibraryProperties LIBNAME)
 	endif()
 
 	# Version
-	set_property(TARGET ${LIBNAME}
-				 PROPERTY VERSION ${Jamoma_VERSION})
-	set_property(TARGET ${LIBNAME}
-				 PROPERTY SOVERSION ${Jamoma_SOVERSION})
-	set_property(TARGET ${LIBNAME} APPEND
-				 PROPERTY COMPATIBLE_INTERFACE_STRING Jamoma_MAJOR_VERSION)
+	if(!BUILD_JAMOMAMAX)
+		set_property(TARGET ${LIBNAME}
+					 PROPERTY VERSION ${Jamoma_VERSION})
+		set_property(TARGET ${LIBNAME}
+					 PROPERTY SOVERSION ${Jamoma_SOVERSION})
+		set_property(TARGET ${LIBNAME} APPEND
+					 PROPERTY COMPATIBLE_INTERFACE_STRING Jamoma_MAJOR_VERSION)
+	endif()
 
 	# TODO replace with target_include_directories
 	if(APPLE)
@@ -40,6 +44,27 @@ function(setupJamomaLibraryProperties LIBNAME)
 					 PROPERTY INTERFACE_INCLUDE_DIRECTORIES
 						$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes>
 						$<INSTALL_INTERFACE:include>)
+
+
+	if(APPLE)
+		if(BUILD_JAMOMAMAX)
+			ADD_CUSTOM_COMMAND(
+			  TARGET ${LIBNAME}
+			  POST_BUILD
+			  COMMAND ${CMAKE_COMMAND} -E make_directory
+			   ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+			)
+			ADD_CUSTOM_COMMAND(
+			  TARGET ${LIBNAME} #Jamoma::Foundation # for instance
+			  POST_BUILD
+			  COMMAND ${CMAKE_COMMAND} -E copy
+			      ${CMAKE_BINARY_DIR}/JamomaCore/${LIBNAME}/library/${CMAKE_BUILD_TYPE}/libJamoma${LIBNAME}.dylib #* # we have to be careful with .so / .dll
+			      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
+			)
+		endif() # BUILD_JAMOMAMAX
+	endif() # APPLE
+
+						
 	else()
 		set_property(TARGET ${LIBNAME} APPEND
 					 PROPERTY INTERFACE_INCLUDE_DIRECTORIES
@@ -99,6 +124,7 @@ function(add_jamoma_library)
 	endif()
 
   if(BUILD_JAMOMAMAX)
+	  
     install(TARGETS ${PROJECT_NAME}
         DESTINATION "${JAMOMAMAX_INSTALL_FOLDER}/Jamoma/support/${SUPPORT_FOLDER}"
         COMPONENT JamomaMax)
@@ -154,6 +180,28 @@ function(add_jamoma_extension)
 			set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".ttdll")
 		endif()
 	endif()
+	
+	
+	
+	if(APPLE)
+		if(BUILD_JAMOMAMAX)
+			ADD_CUSTOM_COMMAND(
+			  TARGET ${PROJECT_NAME}
+			  POST_BUILD
+			  COMMAND ${CMAKE_COMMAND} -E make_directory
+			   ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+			)
+			ADD_CUSTOM_COMMAND(
+			  TARGET ${PROJECT_NAME} #Jamoma::Foundation # for instance
+			  POST_BUILD
+			  COMMAND ${CMAKE_COMMAND} -E copy
+			      ${CMAKE_BINARY_DIR}/JamomaCore/${JAMOMA_CURRENT_LIBRARY_NAME}/extensions/${PROJECT_NAME}/${CMAKE_BUILD_TYPE}/${PROJECT_NAME}.ttdylib #* # we have to be careful with .so / .dll
+			      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
+			)
+		endif() # BUILD_JAMOMAMAX
+	endif() # APPLE
+	
+	
 
 	### Tests ###
 	addTestTarget()

--- a/Shared/CMake/JamomaUtilFunctions.cmake
+++ b/Shared/CMake/JamomaUtilFunctions.cmake
@@ -48,34 +48,35 @@ function(setupJamomaLibraryProperties LIBNAME)
 
 	if(APPLE)
 		if(BUILD_JAMOMAMAX)
+			if(!$ENV{TRAVIS})			
+				# TODO there appears to be some ambiguity when building because some things are build into debug/release even though CMAKE_BUILD_TYPE is the other here... [tap]
 			
-			# TODO there appears to be some ambiguity when building because some things are build into debug/release even though CMAKE_BUILD_TYPE is the other here... [tap]
-			
-			# ADD_CUSTOM_COMMAND(
-			#   TARGET ${LIBNAME}
-			#   POST_BUILD
-			#   COMMAND ${CMAKE_COMMAND} -E make_directory
-			#    ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
-			# )
-			ADD_CUSTOM_COMMAND(
-			  TARGET ${LIBNAME}
-			  POST_BUILD
-			  COMMAND ${CMAKE_COMMAND} -E make_directory
-			   ${CMAKE_BINARY_DIR}/Debug/support
-			)
-			ADD_CUSTOM_COMMAND(
-			  TARGET ${LIBNAME}
-			  POST_BUILD
-			  COMMAND ${CMAKE_COMMAND} -E make_directory
-			   ${CMAKE_BINARY_DIR}/Release/support
-			)
-			ADD_CUSTOM_COMMAND(
-			  TARGET ${LIBNAME} #Jamoma::Foundation # for instance
-			  POST_BUILD
-			  COMMAND ${CMAKE_COMMAND} -E copy
-			      ${CMAKE_BINARY_DIR}/JamomaCore/${LIBNAME}/library/${CMAKE_BUILD_TYPE}/libJamoma${LIBNAME}.dylib #* # we have to be careful with .so / .dll
-			      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
-			)
+				# ADD_CUSTOM_COMMAND(
+				#   TARGET ${LIBNAME}
+				#   POST_BUILD
+				#   COMMAND ${CMAKE_COMMAND} -E make_directory
+				#    ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+				# )
+				ADD_CUSTOM_COMMAND(
+				  TARGET ${LIBNAME}
+				  POST_BUILD
+				  COMMAND ${CMAKE_COMMAND} -E make_directory
+				   ${CMAKE_BINARY_DIR}/Debug/support
+				)
+				ADD_CUSTOM_COMMAND(
+				  TARGET ${LIBNAME}
+				  POST_BUILD
+				  COMMAND ${CMAKE_COMMAND} -E make_directory
+				   ${CMAKE_BINARY_DIR}/Release/support
+				)
+				ADD_CUSTOM_COMMAND(
+				  TARGET ${LIBNAME} #Jamoma::Foundation # for instance
+				  POST_BUILD
+				  COMMAND ${CMAKE_COMMAND} -E copy
+				      ${CMAKE_BINARY_DIR}/JamomaCore/${LIBNAME}/library/${CMAKE_BUILD_TYPE}/libJamoma${LIBNAME}.dylib #* # we have to be careful with .so / .dll
+				      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
+				)
+			endif() # !$ENV{TRAVIS}
 		endif() # BUILD_JAMOMAMAX
 	endif() # APPLE
 

--- a/Shared/CMake/JamomaUtilFunctions.cmake
+++ b/Shared/CMake/JamomaUtilFunctions.cmake
@@ -48,11 +48,26 @@ function(setupJamomaLibraryProperties LIBNAME)
 
 	if(APPLE)
 		if(BUILD_JAMOMAMAX)
+			
+			# TODO there appears to be some ambiguity when building because some things are build into debug/release even though CMAKE_BUILD_TYPE is the other here... [tap]
+			
+			# ADD_CUSTOM_COMMAND(
+			#   TARGET ${LIBNAME}
+			#   POST_BUILD
+			#   COMMAND ${CMAKE_COMMAND} -E make_directory
+			#    ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+			# )
 			ADD_CUSTOM_COMMAND(
 			  TARGET ${LIBNAME}
 			  POST_BUILD
 			  COMMAND ${CMAKE_COMMAND} -E make_directory
-			   ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+			   ${CMAKE_BINARY_DIR}/Debug/support
+			)
+			ADD_CUSTOM_COMMAND(
+			  TARGET ${LIBNAME}
+			  POST_BUILD
+			  COMMAND ${CMAKE_COMMAND} -E make_directory
+			   ${CMAKE_BINARY_DIR}/Release/support
 			)
 			ADD_CUSTOM_COMMAND(
 			  TARGET ${LIBNAME} #Jamoma::Foundation # for instance


### PR DESCRIPTION
…mber in the binary/install_name. Additionally, now copy the binaries for the core into a common location that can be easily copied/linked.